### PR TITLE
Aumenta a visibilidade das classes de atributos

### DIFF
--- a/Minnor.Core/Attributes/ColumnAttribute.cs
+++ b/Minnor.Core/Attributes/ColumnAttribute.cs
@@ -1,14 +1,14 @@
 ﻿namespace Minnor.Core.Attributes;
 
 [AttributeUsage(AttributeTargets.Property)]
-internal class ColumnAttribute : Attribute
+public class ColumnAttribute : Attribute
 {
     #region Properties
-    internal string Name { get; set; }
+    public string Name { get; set; }
     #endregion
 
     #region Constructors
-    internal ColumnAttribute(string name)
+    public ColumnAttribute(string name)
     {
         Name = name;
     }

--- a/Minnor.Core/Attributes/KeyAttribute.cs
+++ b/Minnor.Core/Attributes/KeyAttribute.cs
@@ -1,7 +1,7 @@
 ﻿namespace Minnor.Core.Attributes;
 
 [AttributeUsage(AttributeTargets.Property)]
-internal class KeyAttribute : Attribute
+public class KeyAttribute : Attribute
 {
 
 }

--- a/Minnor.Core/Attributes/TableAttribute.cs
+++ b/Minnor.Core/Attributes/TableAttribute.cs
@@ -1,14 +1,14 @@
 ﻿namespace Minnor.Core.Attributes;
 
 [AttributeUsage(AttributeTargets.Class)]
-internal class TableAttribute : Attribute
+public class TableAttribute : Attribute
 {
     #region Properties
-    internal string Name { get; set; }
+    public string Name { get; set; }
     #endregion
 
     #region Constructors
-    internal TableAttribute(string name)
+    public TableAttribute(string name)
     {
         Name = name;
     }


### PR DESCRIPTION
As classes `ColumnAttribute`, `KeyAttribute` e `TableAttribute` foram alteradas de `internal` para `public`, permitindo acesso externo. As propriedades `Name` e os construtores dessas classes também foram modificados para `public`, melhorando a acessibilidade para outros componentes do sistema.