### PR TITLE
#24  - Atualiza manipulação de expressões SQL

### DIFF
--- a/Minnor.Core/Minnor.Core.csproj
+++ b/Minnor.Core/Minnor.Core.csproj
@@ -8,7 +8,7 @@
     <Company>FeMuniz</Company>
     <Description>Mini ORM </Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>1.0.6</Version>
+    <Version>1.0.7</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">


### PR DESCRIPTION
Adiciona suporte para valores `string` e `DateTime` ao construir expressões SQL, encapsulando-os em aspas simples. Implementa a função `GetValue` para facilitar a recuperação de valores de campos e propriedades em expressões de membro, aumentando a flexibilidade do código.